### PR TITLE
Changes Godot importer to work with Godot version 3.0

### DIFF
--- a/Godot/coa_importer/import_dialog.tscn
+++ b/Godot/coa_importer/import_dialog.tscn
@@ -1,180 +1,399 @@
-[gd_scene format=1]
+[gd_scene format=2]
 
-[node name="Panel" type="ConfirmationDialog"]
+[node name="Panel" type="ConfirmationDialog" index="0"]
 
-margin/right = 982.0
-margin/bottom = 606.0
-focus/ignore_mouse = false
-focus/stop_mouse = false
-size_flags/horizontal = 2
-size_flags/vertical = 2
-popup/exclusive = false
-window/title = "Import Cutout Animation File"
-dialog/hide_on_ok = false
-__meta__ = { "__editor_plugin_screen__":"Script" }
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_right = 982.0
+margin_bottom = 606.0
+rect_min_size = Vector2( 982, 606 )
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
+popup_exclusive = false
+window_title = "Import Cutout Animation File"
+resizable = false
+dialog_hide_on_ok = false
+_sections_unfolded = [ "Anchor", "Margin", "Popup", "Rect", "Size Flags" ]
+__meta__ = {
+"__editor_plugin_screen__": "Script"
+}
 
-[node name="path_source_file" type="Tree" parent="."]
+[node name="VBoxContainer2" type="VBoxContainer" parent="." index="3"]
 
-margin/left = 194.0
-margin/top = 41.0
-margin/right = 938.0
-margin/bottom = 64.0
-focus/ignore_mouse = true
-focus/stop_mouse = false
-size_flags/horizontal = 2
-size_flags/vertical = 2
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 8.0
+margin_top = 8.0
+margin_right = 974.0
+margin_bottom = 570.0
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 1
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
+alignment = 0
 
-[node name="label" type="Label" parent="path_source_file"]
+[node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer2" index="0"]
 
-margin/left = 10.0
-margin/top = 3.0
-margin/right = 737.0
-margin/bottom = 20.0
-focus/ignore_mouse = true
-focus/stop_mouse = true
-size_flags/horizontal = 2
-valign = 1
-percent_visible = 1.0
-lines_skipped = 0
-max_lines_visible = -1
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_right = 966.0
+margin_bottom = 50.0
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 1
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
+alignment = 0
 
-[node name="path_destination_file" type="Tree" parent="."]
+[node name="VBoxContainerButtons" type="VBoxContainer" parent="VBoxContainer2/HBoxContainer2" index="0"]
 
-margin/left = 194.0
-margin/top = 81.0
-margin/right = 938.0
-margin/bottom = 104.0
-focus/ignore_mouse = true
-focus/stop_mouse = false
-size_flags/horizontal = 2
-size_flags/vertical = 2
+editor/display_folded = true
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_right = 153.0
+margin_bottom = 50.0
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 1
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
+alignment = 0
 
-[node name="label" type="Label" parent="path_destination_file"]
+[node name="button_source" type="Button" parent="VBoxContainer2/HBoxContainer2/VBoxContainerButtons" index="0"]
 
-margin/left = 10.0
-margin/top = 3.0
-margin/right = 737.0
-margin/bottom = 20.0
-focus/ignore_mouse = true
-focus/stop_mouse = true
-size_flags/horizontal = 2
-valign = 1
-percent_visible = 1.0
-lines_skipped = 0
-max_lines_visible = -1
-
-[node name="button_source" type="Button" parent="."]
-
-margin/left = 44.0
-margin/top = 39.0
-margin/right = 197.0
-margin/bottom = 66.0
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_right = 153.0
+margin_bottom = 23.0
+rect_min_size = Vector2( 153, 23 )
+rect_pivot_offset = Vector2( 0, 0 )
+focus_mode = 2
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
 toggle_mode = false
+enabled_focus_mode = 2
+shortcut = null
+group = null
 text = "Source File"
 flat = false
+align = 1
+_sections_unfolded = [ "Rect" ]
 
-[node name="button_destination" type="Button" parent="."]
+[node name="button_destination" type="Button" parent="VBoxContainer2/HBoxContainer2/VBoxContainerButtons" index="1"]
 
-margin/left = 44.0
-margin/top = 79.0
-margin/right = 197.0
-margin/bottom = 106.0
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 27.0
+margin_right = 153.0
+margin_bottom = 50.0
+rect_min_size = Vector2( 153, 23 )
+rect_pivot_offset = Vector2( 0, 0 )
+focus_mode = 2
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
 toggle_mode = false
+enabled_focus_mode = 2
+shortcut = null
+group = null
 text = "Destination File"
 flat = false
+align = 1
+_sections_unfolded = [ "Rect" ]
 
-[node name="json_info" type="Tree" parent="."]
+[node name="VBoxContainerFileNames" type="VBoxContainer" parent="VBoxContainer2/HBoxContainer2" index="1"]
 
-margin/left = 43.0
-margin/top = 151.0
-margin/right = 939.0
-margin/bottom = 527.0
-focus/ignore_mouse = true
-focus/stop_mouse = false
-size_flags/horizontal = 2
-size_flags/vertical = 2
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 157.0
+margin_right = 901.0
+margin_bottom = 50.0
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 1
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
+alignment = 0
+_sections_unfolded = [ "Rect" ]
 
-[node name="text" type="RichTextLabel" parent="json_info"]
+[node name="path_source_file" type="Tree" parent="VBoxContainer2/HBoxContainer2/VBoxContainerFileNames" index="0"]
 
-anchor/right = 1
-anchor/bottom = 1
-margin/left = 10.0
-margin/top = 10.0
-margin/right = 10.0
-margin/bottom = 11.0
-focus/ignore_mouse = false
-focus/stop_mouse = false
-size_flags/horizontal = 2
-size_flags/vertical = 2
-bbcode/enabled = false
-bbcode/bbcode = ""
-visible_characters = -1
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_right = 744.0
+margin_bottom = 23.0
+rect_min_size = Vector2( 744, 23 )
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = true
+focus_mode = 2
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
+columns = 1
+allow_reselect = false
+allow_rmb_select = false
+hide_folding = false
+hide_root = false
+drop_mode_flags = 0
+select_mode = 0
+_sections_unfolded = [ "Anchor", "Grow Direction", "Margin", "Rect" ]
 
-[node name="check_merge_scenes" type="CheckBox" parent="."]
+[node name="label" type="Label" parent="VBoxContainer2/HBoxContainer2/VBoxContainerFileNames/path_source_file" index="6"]
 
-margin/left = 44.0
-margin/top = 121.0
-margin/right = 70.0
-margin/bottom = 143.0
-hint/tooltip = "If checked, resource and destination scene get merged. \nCustom Nodes and Animations will be preserved in the destination scene. \n\nOtherwise destination scene gets overwritten."
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_right = 744.0
+margin_bottom = 23.0
+rect_min_size = Vector2( 744, 23 )
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 2
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 2
+size_flags_vertical = 4
+valign = 1
+percent_visible = 1.0
+lines_skipped = 0
+max_lines_visible = -1
+_sections_unfolded = [ "Rect" ]
+
+[node name="path_destination_file" type="Tree" parent="VBoxContainer2/HBoxContainer2/VBoxContainerFileNames" index="1"]
+
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 27.0
+margin_right = 744.0
+margin_bottom = 50.0
+rect_min_size = Vector2( 744, 23 )
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = true
+focus_mode = 2
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
+columns = 1
+allow_reselect = false
+allow_rmb_select = false
+hide_folding = false
+hide_root = false
+drop_mode_flags = 0
+select_mode = 0
+_sections_unfolded = [ "Rect" ]
+
+[node name="label" type="Label" parent="VBoxContainer2/HBoxContainer2/VBoxContainerFileNames/path_destination_file" index="6"]
+
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_right = 744.0
+margin_bottom = 23.0
+rect_min_size = Vector2( 744, 23 )
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 2
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 2
+size_flags_vertical = 4
+valign = 1
+percent_visible = 1.0
+lines_skipped = 0
+max_lines_visible = -1
+_sections_unfolded = [ "Rect" ]
+
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer2" index="1"]
+
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 54.0
+margin_right = 966.0
+margin_bottom = 78.0
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
+
+[node name="check_merge_scenes" type="CheckBox" parent="VBoxContainer2/MarginContainer" index="0"]
+
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 8.0
+margin_right = 270.0
+margin_bottom = 24.0
+rect_pivot_offset = Vector2( 0, 0 )
+focus_mode = 2
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
 toggle_mode = true
-is_pressed = true
+enabled_focus_mode = 2
+shortcut = null
+group = null
 text = "Merge Source and Destination Scene"
 flat = true
 align = 0
+_sections_unfolded = [ "Anchor", "Grow Direction", "Hint", "Margin", "Rect" ]
 
-[node name="file_source" type="FileDialog" parent="."]
+[node name="json_info" type="MarginContainer" parent="VBoxContainer2" index="2"]
 
-visibility/visible = false
-margin/right = 982.0
-margin/bottom = 606.0
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
-popup/exclusive = true
-window/title = "Save a File"
-dialog/hide_on_ok = false
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 82.0
+margin_right = 966.0
+margin_bottom = 532.0
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
 
-[node name="file_destination" type="FileDialog" parent="."]
+[node name="text" type="RichTextLabel" parent="VBoxContainer2/json_info" index="0"]
 
-visibility/visible = false
-margin/right = 982.0
-margin/bottom = 606.0
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
-popup/exclusive = true
-window/title = "Save a File"
-dialog/hide_on_ok = false
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 8.0
+margin_right = 903.0
+margin_bottom = 450.0
+rect_min_size = Vector2( 895, 450 )
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = true
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
+bbcode_enabled = false
+bbcode_text = ""
+visible_characters = -1
+percent_visible = 1.0
+meta_underlined = true
+tab_size = 4
+text = ""
+scroll_active = true
+scroll_following = false
+selection_enabled = false
+override_selected_font_color = false
+_sections_unfolded = [ "Rect" ]
 
-[node name="warning_dialog" type="AcceptDialog" parent="."]
+[node name="file_source" type="FileDialog" parent="." index="4"]
 
-visibility/visible = false
-margin/left = 326.0
-margin/top = 211.0
-margin/right = 611.0
-margin/bottom = 365.0
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
-popup/exclusive = true
-window/title = "Warning"
-dialog/text = "Please select Source and Destination File"
-dialog/hide_on_ok = true
+visible = false
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 8.0
+margin_top = 8.0
+margin_right = 974.0
+margin_bottom = 570.0
+rect_min_size = Vector2( 200, 70 )
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
+popup_exclusive = true
+window_title = "Save a File"
+resizable = false
+dialog_hide_on_ok = false
+mode_overrides_title = true
+mode = 4
+access = 0
+filters = PoolStringArray(  )
+show_hidden_files = false
+current_dir = "res://"
+current_file = ""
+current_path = "res://"
+_sections_unfolded = [ "Visibility" ]
+
+[node name="file_destination" type="FileDialog" parent="." index="5"]
+
+visible = false
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 8.0
+margin_top = 8.0
+margin_right = 974.0
+margin_bottom = 570.0
+rect_min_size = Vector2( 200, 70 )
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
+popup_exclusive = true
+window_title = "Save a File"
+resizable = false
+dialog_hide_on_ok = false
+mode_overrides_title = true
+mode = 4
+access = 0
+filters = PoolStringArray(  )
+show_hidden_files = false
+current_dir = "res://"
+current_file = ""
+current_path = "res://"
+_sections_unfolded = [ "Visibility" ]
+
+[node name="warning_dialog" type="AcceptDialog" parent="." index="6"]
+
+visible = false
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 8.0
+margin_top = 8.0
+margin_right = 974.0
+margin_bottom = 570.0
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
+popup_exclusive = true
+window_title = "Warning"
+resizable = false
+dialog_text = "Please select Source and Destination File"
+dialog_hide_on_ok = true
+_sections_unfolded = [ "Anchor", "Dialog", "Focus", "Hint", "Margin", "Material", "Mouse", "Popup", "Rect", "Size Flags", "Theme", "Visibility" ]
 
 

--- a/Godot/coa_importer/importer.gd
+++ b/Godot/coa_importer/importer.gd
@@ -32,29 +32,30 @@ var root_node
 func _init():
 	print("PLUGIN INIT")
 
-	
 func _enter_tree():
 	import_window = import_window_res.instance()
 	import_window.connect("confirmed",self,"_create_imported_scene")
-	
-	
-	json_info = import_window.get_node("json_info/text")
-	
-	check_merge = import_window.get_node("check_merge_scenes")
-	
-	label_dst_scene = import_window.get_node("path_destination_file/label")
-	label_src_scene = import_window.get_node("path_source_file/label")
-	
+
+
+	json_info = import_window.get_node("VBoxContainer2/json_info/text")
+
+	check_merge = import_window.get_node("VBoxContainer2/MarginContainer/check_merge_scenes")
+
+	label_dst_scene = import_window.get_node("VBoxContainer2/HBoxContainer2/VBoxContainerFileNames/path_destination_file/label")
+	label_src_scene = import_window.get_node("VBoxContainer2/HBoxContainer2/VBoxContainerFileNames/path_source_file/label")
+
 	warning_dialog = import_window.get_node("warning_dialog")
-	
+
 	#src_dialog = import_window.get_node("file_source")
 	src_dialog = EditorFileDialog.new()
 	src_dialog.set_access(src_dialog.ACCESS_FILESYSTEM)
 	src_dialog.set_mode(src_dialog.MODE_OPEN_FILE)
 	src_dialog.add_filter("*.json")
 	src_dialog.connect("file_selected",self,"_src_dialog_confirm")
-	get_base_control().add_child(src_dialog)
-	
+	get_editor_interface().get_base_control().add_child(src_dialog)
+
+
+
 	#dst_dialog = import_window.get_node("file_destination")
 	dst_dialog = EditorFileDialog.new()
 	dst_dialog.set_access(dst_dialog.ACCESS_RESOURCES)
@@ -63,30 +64,30 @@ func _enter_tree():
 	dst_dialog.add_filter("*.tscn")
 	dst_dialog.add_filter("*.scn")
 	dst_dialog.connect("file_selected",self,"_dst_dialog_confirm")
-	get_base_control().add_child(dst_dialog)
-	
-	
-	get_base_control().add_child(import_window)
+	get_editor_interface().get_base_control().add_child(dst_dialog)
+
+
+	get_editor_interface().get_base_control().add_child(import_window)
 	import_window.get_ok().set_text("Import")
-	btn_load_json = import_window.get_node("button_source")
+	btn_load_json = import_window.get_node("VBoxContainer2/HBoxContainer2/VBoxContainerButtons/button_source")
 	btn_load_json.connect("pressed",self,"_open_src_dialog")
-	
-	btn_dst_file = import_window.get_node("button_destination")
+
+	btn_dst_file = import_window.get_node("VBoxContainer2/HBoxContainer2/VBoxContainerButtons/button_destination")
 	btn_dst_file.connect("pressed",self,"_open_dst_dialog")
-	
-	
-	
+
+
+
 	open_importer = Button.new()
 	open_importer.set_text("Import COA File")
 	open_importer.connect("pressed",self,"_open_importer")
 	#add_custom_control(CONTAINER_CANVAS_EDITOR_MENU,open_importer)
 	add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, open_importer)
-	
-	
+
+
 func _exit_tree():
 	open_importer.free()
 	open_importer = null
-	
+
 	import_window.free()
 	import_window = null
 
@@ -94,21 +95,23 @@ func _exit_tree():
 ### function to open the main importer window where source and destination files can be set
 func _open_importer():
 	### center window
-	var pos = OS.get_window_size()*0.5 - import_window.get_size()*0.5
-	import_window.set_pos(pos)
+	var pos = OS.get_window_size()*0.5 - import_window.get_rect().size*0.5
+	print(pos)
+	import_window.rect_position = pos
 
 	json_info.clear()
 	import_window.popup_centered()
-	
+
 	if json_path != "":
 		_src_dialog_confirm(json_path)
-	if file_dst_path != "":	
+	if file_dst_path != "":
 		_dst_dialog_confirm(file_dst_path)
 
 
 ### this will open the dialog to load in the source json file
 func _open_src_dialog():
-	json_info.set_ignore_mouse(true)
+	print("_open_src_dialog")
+	#json_info.set_ignore_mouse(true)
 	src_dialog.popup_centered_ratio()
 	src_scene = null
 	#src_dialog.set_pos(import_window.get_pos())
@@ -117,27 +120,27 @@ func _open_src_dialog():
 ### once the src file dialog is confirmed this will load in the json file and prepare a log file with some information that is gathered from the json file
 func _src_dialog_confirm(path):
 	json_info.clear()
-	json_info.set_ignore_mouse(false)
+	#json_info.set_ignore_mouse(false)
 	json_path = path
 	var json = File.new()
 	if json.file_exists(json_path):
-		
+
 		json.open(json_path,File.READ)
-		json_data.parse_json(json.get_as_text())
+		json_data = parse_json(json.get_as_text())
 		json.close()
-		
+
 		label_src_scene.set_text(json_path)
-	
+
 	dir = Directory.new()
 	dir.open("res://")
-	
+
 	if src_scene != null:
 		src_scene.free()
 	src_scene = Node2D.new()
 	src_scene.set_name(json_data["name"])
 	write_log(json_info,"Json import File Information")
 	json_info.newline()
-	
+
 	if "changelog" in json_data:
 		write_log(json_info,"#### Changelog ####")
 		for log_msg in json_data["changelog"]:
@@ -151,15 +154,15 @@ func _src_dialog_confirm(path):
 	create_nodes(json_data["nodes"],src_scene,src_scene,false)
 	write_log(json_info,str("Sprite Count: ",sprite_count),0)
 	write_log(json_info,str("Bone Count:   ",bone_count),0)
-	
+
 	### import animations and log
 	import_animations(json_data["animations"],src_scene)
 	src_scene = src_scene
-	
+
 
 ### this will open the dialog to say where to save the imported json file as godots scene file
 func _open_dst_dialog():
-	json_info.set_ignore_mouse(true)
+	#json_info.set_ignore_mouse(true)
 	dst_dialog.popup_centered_ratio()
 	dst_scene = null
 	#dst_dialog.set_pos(import_window.get_pos())
@@ -167,13 +170,13 @@ func _open_dst_dialog():
 
 ### this will load in the scene file if is selected with the destination file dialog and it sets the global path for the dst file
 func _dst_dialog_confirm(path):
-	json_info.set_ignore_mouse(false)
+	#json_info.set_ignore_mouse(false)
 
 	file_dst_path = path
 	var file = File.new()
 	label_dst_scene.set_text(file_dst_path)
 	if file.file_exists(file_dst_path):
-		
+
 		var dst_scene_res = load(file_dst_path)
 		dst_scene = dst_scene_res.instance()
 
@@ -181,7 +184,7 @@ func _dst_dialog_confirm(path):
 func save_packed_scene(scene):
 	if scene.has_node("AnimationPlayer"):
 		scene.get_node("AnimationPlayer").clear_caches()
-	
+
 	# pack scene and save
 	var outfile = PackedScene.new()
 	outfile.pack(scene)
@@ -191,35 +194,35 @@ func save_packed_scene(scene):
 ### this function actually imports the json file
 func _create_imported_scene():
 	if file_dst_path != "" and json_path != "":
-		
+
 		### if destination scene exists already, transfer root node otherwise create Node2D
 		if src_scene != null:
 			src_scene.free()
-		if dst_scene != null and check_merge.is_pressed():	
+		if dst_scene != null and check_merge.is_pressed():
 			src_scene = Node2D.new()
 			src_scene.replace_by(dst_scene)
 		else:
 			src_scene = Node2D.new()
 		src_scene.set_name(json_data["name"])
-		
+
 		### Create all nodes from Json File
 		create_nodes(json_data["nodes"],src_scene,src_scene)
-		
-		### Import all Animations 
+
+		### Import all Animations
 		if "animations" in json_data:
 			import_animations(json_data["animations"],src_scene)
 			src_scene = src_scene
-		
+
 		### if merging is enabled, make a clever update and preserve local changes, update imported nodes and delete not available nodes
 		if dst_scene != null and check_merge.is_pressed():
 			save_packed_scene(merge_scenes(src_scene,dst_scene))
 			import_window.hide()
-		### make a simple import and write all data into scene	
+		### make a simple import and write all data into scene
 		else:
 			save_packed_scene(src_scene)
 			import_window.hide()
-			
-			
+
+
 		show_warning_dialog("Info","Import complete, please reload Scene.")
 	else:
 		show_warning_dialog()
@@ -235,20 +238,20 @@ func get_child_recursive(node,child_list=[]):
 
 ### this function updates a node with another one. it will update all relevant node properties with the once to replace
 func replace_node(node, replace_with):
-	if node.get_type() == "Node2D" or node.get_type() == "Sprite":
-		node.set_pos(replace_with.get_pos())
-		node.set_rot(replace_with.get_rot())
-		node.set_scale(replace_with.get_scale())
-		node.set_opacity(replace_with.get_opacity())
-		node.set_z(replace_with.get_z())
-		if node.get_type() == "Sprite":
-			node.set_texture(replace_with.get_texture())
-			node.set_hframes(replace_with.get_hframes())
-			node.set_vframes(replace_with.get_vframes())
-			node.set_frame(replace_with.get_frame())
-			node.set_centered(replace_with.is_centered())
-			node.set_offset(replace_with.get_offset())
-	elif node.get_type() == "AnimationPlayer":
+	if node.get_class() == "Node2D" or node.get_class() == "Sprite":
+		node.position = replace_with.position
+		node.rotation_degrees = replace_with.rotation_degrees
+		node.scale = replace_with.scale
+		node.opacity = replace_with.opacity
+		node.z_index = replace_with.z_index
+		if node.get_class() == "Sprite":
+			node.texture = replace_with.texture
+			node.hframes = replace_with.hframes
+			node.vframes = replace_with.vframes
+			node.frame = replace_with.frame
+			node.centered = replace_with.centered
+			node.offset = replace_with.offset
+	elif node.get_class() == "AnimationPlayer":
 		### delete not available animations that are imported from blender
 		var anim_list = node.get_animation_list()
 		for anim in anim_list:
@@ -256,9 +259,9 @@ func replace_node(node, replace_with):
 				node.set_meta(anim,false)
 				node.remove_animation(anim)
 				node.clear_caches()
-	
+
 		### update animations and add new animations
-		var anim_list = replace_with.get_animation_list()
+		anim_list = replace_with.get_animation_list()
 		for anim in anim_list:
 			if node.has_animation(anim):
 				node.get_animation(anim).clear()
@@ -272,7 +275,7 @@ func get_parent_nodes(list):
 	var parent_list = []
 	for node in list:
 		if node.get_parent() != null:
-			if !(node.get_parent() in list):
+#			if !(node.get_parent() in list):
 				parent_list.append(node)
 	return parent_list
 
@@ -284,8 +287,8 @@ func add_node_recursive(node,owner,parent):
 	if node.get_child_count() > 0:
 		for child in node.get_children():
 			add_node_recursive(child,owner,node)
-			
-### function to cleverly merge source and destination scene	
+
+### function to cleverly merge source and destination scene
 func merge_scenes(src_scene,dst_scene):
 
 	### delete nodes that are not available in the src scene anymore and are imported from blender
@@ -298,21 +301,21 @@ func merge_scenes(src_scene,dst_scene):
 				to_be_deleted.append(node)
 	for node in get_parent_nodes(to_be_deleted):
 		node.free()
-			
+
 	### update nodes from src scene and add new nodes if they are not available
 	var node_src_scene = get_child_recursive(src_scene)
 	for node in node_src_scene:
 		var node_path = src_scene.get_path_to(node)
 		if dst_scene.has_node(node_path):
 			var node2 = dst_scene.get_node(node_path)
-			
+
 			replace_node(node2,node)
 		else:
 			var new_nodes = node.duplicate()
 			var parent_node = dst_scene.get_node(src_scene.get_path_to(node.get_parent()))
 			add_node_recursive(new_nodes,dst_scene,parent_node)
 	return dst_scene
-		
+
 
 ### a function to write logs when loading in a json file
 func write_log(text_field,msg,indent=0,line_break=false):
@@ -328,9 +331,9 @@ func show_warning_dialog(title="",msg=""):
 		warning_dialog.set_text(msg)
 	if title != "":
 		warning_dialog.set_title(title)
-		
-	var pos = import_window.get_pos() + import_window.get_size()*0.5 - warning_dialog.get_size()*0.5
-	
+
+	var pos = import_window.rect_position + import_window.get_rect().size*0.5 - warning_dialog.get_rect().size*0.5
+
 
 ### recursive function that looks up if a node has BONE nodes as children
 func has_bone_child(node):
@@ -348,7 +351,7 @@ func import_animations(animations,owner):
 	owner.add_child(anim_player)
 	anim_player.set_owner(owner)
 	anim_player.set_name("AnimationPlayer")
-	
+
 	write_log(json_info,str("Animation Count: ",animations.size()))
 	if animations.size() > 0:
 		write_log(json_info,str("#### Animations ####"),0,true)
@@ -359,9 +362,16 @@ func import_animations(animations,owner):
 		anim_data.set_loop(true)
 		anim_data.set_length(anim["length"])
 		for key in anim["keyframes"]:
+			print("key " + key)
+			var trackPath =  key
+			# godot 3 redefined tramsorm attributes
+			trackPath = trackPath.replace("transform/pos", "position")
+			trackPath = trackPath.replace("transform/rot", "rotation_degrees")
+			#trackPath = trackPath.replace("transform/scale:", "scale")
+			print("trackPath " + trackPath)
 			var track = anim["keyframes"][key]
 			var idx = anim_data.add_track(Animation.TYPE_VALUE)
-			anim_data.track_set_path(idx,key)
+			anim_data.track_set_path(idx,trackPath)
 			for time in track:
 				var value = track[time]["value"]
 				if typeof(value) == TYPE_ARRAY:
@@ -384,13 +394,13 @@ func import_animations(animations,owner):
 		anim_player.add_animation(anim["name"],anim_data)
 		anim_player.set_meta(anim["name"],true)
 		anim_player.clear_caches()
-	
+
 ### this function generates the complete node structur that is stored in a json file. Generates SPRITE and BONE nodes.
 func create_nodes(nodes,parent,subparent,copy_images=true,i=0):
 	var dir2 = Directory.new()
 	dir2.open("res://")
 	for node in nodes:
-		
+
 		var new_node
 		var offset = Vector2(0,0)
 		if "offset" in node:
@@ -399,24 +409,24 @@ func create_nodes(nodes,parent,subparent,copy_images=true,i=0):
 			bone_count += 1
 			new_node = Node2D.new()
 			new_node.set_meta("imported_from_blender",true)
-			new_node.set_name(node["name"])
-			new_node.set_pos(Vector2(node["position"][0],node["position"][1]))
-			new_node.set_rot(node["rotation"])
-			new_node.set_scale(Vector2(node["scale"][0],node["scale"][1]))	
-			new_node.set_z(node["z"])
+			new_node.name = node["name"]
+			new_node.position = Vector2(node["position"][0],node["position"][1])
+			new_node.rotation_degrees = node["rotation"]
+			new_node.scale = Vector2(node["scale"][0],node["scale"][1])
+			new_node.z_index = node["z"]
 			subparent.add_child(new_node)
 			new_node.set_owner(parent)
-			
+
 			### handle bone drawing
 			if new_node.get_parent() != null and node["bone_connected"]:
 				new_node.set_meta("_edit_bone_",true)
 			if !(has_bone_child(node)) or node["draw_bone"]:
 				var draw_bone = Node2D.new()
 				draw_bone.set_meta("_edit_bone_",true)
-				draw_bone.set_name(str(node["name"],"_tail"))
-				draw_bone.set_pos(Vector2(node["position_tip"][0],-node["position_tip"][1]))
+				draw_bone.name = str(node["name"],"_tail")
+				draw_bone.position = Vector2(node["position_tip"][0],-node["position_tip"][1])
 				draw_bone.hide()
-				
+
 				new_node.add_child(draw_bone)
 				draw_bone.set_owner(parent)
 
@@ -427,32 +437,32 @@ func create_nodes(nodes,parent,subparent,copy_images=true,i=0):
 			if copy_images:
 				if json_path != "":
 					var sprite_dir_path = file_dst_path.get_base_dir()
-					
+
 					if !(dir.dir_exists(str(sprite_dir_path,"/sprites"))):
 						dir.make_dir(str(sprite_dir_path,"/sprites"))
 					if dir.file_exists(str(json_path.get_base_dir(),"/",node["resource_path"])):
 						var _src = str(json_path.get_base_dir(),"/",node["resource_path"])
 						var _dst = str(sprite_dir_path,"/",node["resource_path"])
 						dir.copy(_src,_dst)
-						
+
 						### set sprite texture
 						new_node.set_texture(load(str(sprite_dir_path,"/",node["resource_path"])))
-		
+
 			new_node.set_meta("imported_from_blender",true)
-			new_node.set_name(node["name"])
-			new_node.set_hframes(node["tiles_x"])
-			new_node.set_vframes(node["tiles_y"])
-			new_node.set_frame(node["frame_index"])
-			new_node.set_centered(false)
-			new_node.set_offset(Vector2(node["pivot_offset"][0],node["pivot_offset"][1]))
-			new_node.set_pos(Vector2(node["position"][0]+offset[0],node["position"][1]+offset[0]))
-			new_node.set_rot(node["rotation"])
-			new_node.set_scale(Vector2(node["scale"][0],node["scale"][1]))
-			new_node.set_z(node["z"])
-			
+			new_node.name = node["name"]
+			new_node.hframes = node["tiles_x"]
+			new_node.vframes = node["tiles_y"]
+			new_node.frame = node["frame_index"]
+			new_node.centered = false
+			new_node.offset = Vector2(node["pivot_offset"][0],node["pivot_offset"][1])
+			new_node.position = Vector2(node["position"][0]+offset[0],node["position"][1]+offset[0])
+			new_node.rotation_degrees = node["rotation"]
+			new_node.scale = Vector2(node["scale"][0],node["scale"][1])
+			new_node.z_index = node["z"]
+
 			subparent.add_child(new_node)
 			new_node.set_owner(parent)
-		
+
 		if "children" in node and node["children"].size() > 0:
 			i+=1
 			create_nodes(node["children"],parent,new_node,copy_images,i)


### PR DESCRIPTION
Ran into some problems using the importer in 3.0 so here are some changes I made to get it working on the Godot 3.0 branch of the game engine.

1. Dialog box was not expanding to fit widgets. I added containers but suspect this can be simplified to using minimum width settings on each widget and keeping all the original container structure.
2. Sciipt changed to support the 3.0 way of getting to the Node data and to the new paths for the dialog box widgets.
3. Support the new animation node track names. The transform attributes have changed. 

Note: I see I forgot to remove some debug print statements. And I didn't test all paths through the code. But the importer does load a Blender json export and animate. (For my simple test scene). 