### PR TITLE
default export path to document path

### DIFF
--- a/Photoshop/BlenderExporter.jsx
+++ b/Photoshop/BlenderExporter.jsx
@@ -349,8 +349,16 @@ with(win){
 	win.export_json = add( "checkbox", [5,130,180,150], 'Export Json File' );
 	win.crop_layers = add( "checkbox", [5,90,180,110], 'Crop Layers' );
 	}
-win.export_path.text = app.activeDocument.info.caption;
-win.export_name.text = app.activeDocument.info.captionWriter;
+if (app.activeDocument.info.caption != ''){
+    win.export_path.text = app.activeDocument.info.caption;
+    }else{
+    win.export_path.text = app.activeDocument.path;    
+    }
+if (app.activeDocument.info.captionWriter != ''){
+    win.export_name.text = app.activeDocument.info.captionWriter;
+    }else{
+    win.export_name.text = app.activeDocument.name.split('.')[0];
+    }
 win.export_button.onClick = export_button;
 win.button_path.onClick = path_button;
 win.center_sprites.value = true;


### PR DESCRIPTION
when no export path has been set for the document, it use the document path.
Same for the export name, it uses the document name.