### PR TITLE
Typo fix in error message

### DIFF
--- a/Blender/coa_tools/operators/slot_handling.py
+++ b/Blender/coa_tools/operators/slot_handling.py
@@ -109,7 +109,7 @@ class CreateSlotObject(bpy.types.Operator):
     
     def execute(self, context):
         if not self.objects_are_valid(context):
-            self.report({'INFO'},"Please select at least to Sprites to combine into a slot.")
+            self.report({'INFO'},"Please select at least two Sprites to combine into a slot.")
             return{"CANCELLED"}
         
         name = str(context.active_object.name)


### PR DESCRIPTION
Fix typo in error message while trying to merge a single sprite to slot