### PR TITLE
Fixed required write access to Blender installation files to install custom icons

### DIFF
--- a/Blender/coa_tools/__init__.py
+++ b/Blender/coa_tools/__init__.py
@@ -262,7 +262,7 @@ def unregister_keymaps():
 
 def register():
     addon_updater_ops.register(bl_info)
-    copy_icons()
+    #copy_icons()
 
     # register classes
     for cls in classes:
@@ -357,31 +357,3 @@ def update_properties(scene, depsgraph):
         if obj_eval.coa_tools.z_value != obj_eval.coa_tools.z_value_last:
             set_z_value(context, obj, obj_eval.coa_tools.z_value)
             obj.coa_tools.z_value_last = obj_eval.coa_tools.z_value
-
-
-
-def copy_icons():
-    version = str(bpy.app.version[0]) + "." + str(bpy.app.version[1])
-
-    icons = [
-        "coa_tools.draw_polygon.dat",
-        "coa_tools.draw_bone.dat",
-        ]
-
-    for icon_name in icons:
-        icon_path = os.path.join(bpy.utils.user_resource("SCRIPTS", "addons"), "coa_tools", "icons", icon_name)
-        b_icon_path = os.path.join(os.path.dirname(bpy.app.binary_path), version, "datafiles", "icons", icon_name)
-
-        if os.path.isfile(b_icon_path):
-            try:
-                os.remove(b_icon_path)
-            except IOError as e:
-                print("Unable to delete file. %s" % e)
-
-        dir_path = os.path.dirname(b_icon_path)
-        if not os.path.exists(dir_path):
-            os.makedirs(dir_path)
-        try:
-            shutil.copyfile(icon_path, b_icon_path)
-        except IOError as e:
-            print("Unable to copy file. %s" % e)

--- a/Blender/coa_tools/__init__.py
+++ b/Blender/coa_tools/__init__.py
@@ -262,7 +262,6 @@ def unregister_keymaps():
 
 def register():
     addon_updater_ops.register(bl_info)
-    #copy_icons()
 
     # register classes
     for cls in classes:

--- a/Blender/coa_tools/functions.py
+++ b/Blender/coa_tools/functions.py
@@ -342,6 +342,9 @@ def update_uv_unwrap(context):
 def clamp(n, minn, maxn):
     return max(min(maxn, n), minn)
 
+def get_coa_tools_dir():
+    return os.path.dirname(os.path.abspath(__file__))
+
 def b_version_bigger_than(version):
     if bpy.app.version > version:
         return True

--- a/Blender/coa_tools/operators/edit_armature.py
+++ b/Blender/coa_tools/operators/edit_armature.py
@@ -91,12 +91,12 @@ class COATOOLS_TO_DrawBone(bpy.types.WorkSpaceTool):
     bl_context_mode = 'EDIT_ARMATURE'
 
     # The prefix of the idname should be your add-on name.
-    bl_idname = os.path.join(functions.get_coa_tools_dir(), "icons", "coa_tools.draw_bone")
+    bl_idname = "coa_tools.draw_bone"
     bl_label = "Draw Bone"
     bl_description = (
         "Draws Bones"
     )
-    bl_icon = "coa_tools.draw_bone"
+    bl_icon = os.path.join(functions.get_coa_tools_dir(), "icons", "coa_tools.draw_bone")
     bl_widget = None
     # bl_keymap = (
     #     ("coa_tools.draw_polygon", {"type": 'LEFTMOUSE', "value": 'PRESS'}, None),

--- a/Blender/coa_tools/operators/edit_armature.py
+++ b/Blender/coa_tools/operators/edit_armature.py
@@ -17,7 +17,8 @@ Created by Andreas Esau
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
-    
+
+import os
 import bpy
 import bpy_extras
 import bpy_extras.view3d_utils
@@ -90,7 +91,7 @@ class COATOOLS_TO_DrawBone(bpy.types.WorkSpaceTool):
     bl_context_mode = 'EDIT_ARMATURE'
 
     # The prefix of the idname should be your add-on name.
-    bl_idname = "coa_tools.draw_bone"
+    bl_idname = os.path.join(functions.get_coa_tools_dir(), "icons", "coa_tools.draw_bone")
     bl_label = "Draw Bone"
     bl_description = (
         "Draws Bones"

--- a/Blender/coa_tools/operators/edit_mesh.py
+++ b/Blender/coa_tools/operators/edit_mesh.py
@@ -17,7 +17,8 @@ Created by Andreas Esau
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
-    
+
+import os
 import bpy
 import bpy_extras
 import bpy_extras.view3d_utils
@@ -487,7 +488,7 @@ class COATOOLS_TO_DrawPolygon(bpy.types.WorkSpaceTool):
     bl_description = (
         "Draws COA Tools Mesh Polygon"
     )
-    bl_icon = "coa_tools.draw_polygon"
+    bl_icon = os.path.join(functions.get_coa_tools_dir(), "icons", "coa_tools.draw_polygon")
     bl_widget = None
     # bl_keymap = (
     #     ("coa_tools.draw_polygon", {"type": 'LEFTMOUSE', "value": 'PRESS'}, None),


### PR DESCRIPTION
This should close #167 and #160.

This pull request adds a small function to find from which folder the addon is running, and also fixes an issue which prevented installation without write access to the Blender installation folders. The icons still show as normal.