### PR TITLE
Fix importing of JSON files, generated by Krita's Batch Exporter

### DIFF
--- a/Blender/coa_tools/operators/import_sprites.py
+++ b/Blender/coa_tools/operators/import_sprites.py
@@ -132,7 +132,7 @@ class LoadJsonData(bpy.types.Operator):
                             bpy.ops.coa_tools.coa_import_sprite(path=filepath,parent=sprite_object.name,scale=scale,pos=pos,tilesize=tilesize,offset=offset)
                     
                     
-                    obj = bpy.data.objects[sprite["name"]]
+                    obj = bpy.data.objects[os.path.basename(sprite["resource_path"])]
                     obj.parent = sprite_object
                 
         context.scene.objects.active = sprite_object    


### PR DESCRIPTION
This PR fixes issue with importing this JSON (generated by Krita's Batch Exporter) - 
[pepper-head.zip](https://github.com/ndee85/coa_tools/files/9298093/pepper-head.zip)

Here is a video showing the bug -
https://youtu.be/54_-PEYy-Qk