### PR TITLE
[Blender 3.3.1] `Convert COA Data` fix `RuntimeError: IDPropertyGroup changed size during iteration`

### DIFF
--- a/Blender/coa_tools/operators/version_converter.py
+++ b/Blender/coa_tools/operators/version_converter.py
@@ -60,7 +60,7 @@ class COATOOLS_OT_VersionConverter(bpy.types.Operator):
             if "sprite_object" in obj:
                 obj.coa_tools["sprite_object"] = True
                 del obj["sprite_object"]
-            for prop_name in obj.keys():
+            for prop_name in list(obj.keys()):
                 if "coa_" in prop_name and "coa_tools" not in prop_name:
                     prop_name_new = prop_name.split("coa_")[1]
                     obj.coa_tools[prop_name_new] = obj[prop_name]


### PR DESCRIPTION
I'm not a python programmer, so I don't know what I'm doing. 🤷‍♂️ I just googled the error and found the solution on Stack Overflow. 

Fixes:
```
Python: Traceback (most recent call last):
  File "%AppData%\Blender Foundation\Blender\3.3\scripts\addons\coa_tools\operators\version_converter.py", line 170, in execute
    self.convert_properties()
  File "%AppData%\Blender Foundation\Blender\3.3\scripts\addons\coa_tools\operators\version_converter.py", line 63, in convert_properties
    for prop_name in obj.keys():
RuntimeError: IDPropertyGroup changed size during iteration
```